### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -18,8 +18,8 @@ highWord	KEYWORD2
 LONG	KEYWORD2
 
 begin	KEYWORD2
-setSlave    KEYWORD2
-setUSART    KEYWORD2
+setSlave	KEYWORD2
+setUSART	KEYWORD2
 
 getResponseBuffer	KEYWORD2
 clearResponseBuffer	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords